### PR TITLE
Set qemu to headless true

### DIFF
--- a/rhel65.json
+++ b/rhel65.json
@@ -142,7 +142,7 @@
       "shutdown_command": "shutdown -P now",
       "disk_size": 5000,
       "format": "qcow2",
-      "headless": false,
+      "headless": true,
       "accelerator": "kvm",
       "http_directory": "http",
       "http_port_min": 10082,


### PR DESCRIPTION
If using packer in a VM or no gui environment QEMU will throw an error regarding a missing SDL device.
